### PR TITLE
test: add missing tests for Entity+Edge model migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME="github.com/raystack/meteor"
 VERSION=$(shell git describe --always --tags 2>/dev/null)
 COVERFILE="/tmp/app.coverprofile"
-PROTON_COMMIT := "ae895e033f71df187c62d7cf9431a2e259ddd423"
+PROTON_COMMIT := "f5514e23005e7480319a18ba905dfecaa17379f8"
 .PHONY: all build clean test
 
 all: build
@@ -36,7 +36,7 @@ test-coverage:
 generate-proto:
 	@echo " > cloning protobuf from raystack/proton"
 	@echo " > generating protobuf"
-	@buf generate --template buf.gen.yaml https://github.com/raystack/proton/archive/${PROTON_COMMIT}.zip#strip_components=1 --path raystack/assets/v1beta2
+	@buf generate --template buf.gen.yaml https://github.com/raystack/proton/archive/${PROTON_COMMIT}.zip#strip_components=1 --path raystack/meteor/v1beta1
 	@echo " > protobuf compilation finished"
 
 lint:

--- a/docs/docs/concepts/context_graph.md
+++ b/docs/docs/concepts/context_graph.md
@@ -19,11 +19,11 @@ Meteor operates as a metadata supply chain with three stages:
 
 ### Extract
 
-Meteor's extractors connect to 30+ data sources — databases (BigQuery, Postgres, Snowflake), BI tools (Tableau, Metabase, Superset), streaming platforms (Kafka), cloud storage (GCS), orchestrators (Optimus), and more. Each extractor produces standardized **Asset** records containing:
+Meteor's extractors connect to 30+ data sources — databases (BigQuery, Postgres, Snowflake), BI tools (Tableau, Metabase, Superset), streaming platforms (Kafka), cloud storage (GCS), orchestrators (Optimus), and more. Each extractor produces **Record**s — an **Entity** with flat properties plus **Edge**s representing relationships:
 
-- **Schema metadata** — column names, types, descriptions, constraints
-- **Lineage** — upstream and downstream asset references
-- **Ownership** — who owns and maintains the asset
+- **Schema metadata** — column names, types, descriptions, constraints (stored as entity properties)
+- **Lineage** — upstream and downstream relationships (represented as edges)
+- **Ownership** — who owns and maintains the entity (represented as edges)
 - **Service context** — source system, URLs, timestamps
 
 ### Process

--- a/models/record_test.go
+++ b/models/record_test.go
@@ -34,3 +34,36 @@ func TestNewRecordWithEdges(t *testing.T) {
 	assert.Len(t, record.Edges(), 1)
 	assert.Equal(t, edge, record.Edges()[0])
 }
+
+func TestNewRecordWithMultipleEdges(t *testing.T) {
+	entity := &meteorv1beta1.Entity{
+		Urn:  "urn:test:scope:table:t1",
+		Name: "t1",
+		Type: "table",
+	}
+	lineageEdge := &meteorv1beta1.Edge{
+		SourceUrn: "urn:test:scope:table:t1",
+		TargetUrn: "urn:test:scope:table:t2",
+		Type:      "lineage",
+		Source:    "test",
+	}
+	ownerEdge := &meteorv1beta1.Edge{
+		SourceUrn: "urn:test:scope:table:t1",
+		TargetUrn: "urn:user:alice@co.com",
+		Type:      "owned_by",
+		Source:    "test",
+	}
+	record := models.NewRecord(entity, lineageEdge, ownerEdge)
+	assert.Equal(t, entity, record.Entity())
+	assert.Len(t, record.Edges(), 2)
+	assert.Equal(t, lineageEdge, record.Edges()[0])
+	assert.Equal(t, ownerEdge, record.Edges()[1])
+	assert.Equal(t, "lineage", record.Edges()[0].GetType())
+	assert.Equal(t, "owned_by", record.Edges()[1].GetType())
+}
+
+func TestNewRecordWithNilEntity(t *testing.T) {
+	record := models.NewRecord(nil)
+	assert.Nil(t, record.Entity())
+	assert.Empty(t, record.Edges())
+}

--- a/models/util_test.go
+++ b/models/util_test.go
@@ -88,3 +88,66 @@ func TestRecordToJSON(t *testing.T) {
 	assert.Contains(t, string(b), `"entity"`)
 	assert.Contains(t, string(b), `"edges"`)
 }
+
+func TestNewEntityWithNilProps(t *testing.T) {
+	entity := models.NewEntity("urn:test:s:table:t1", "table", "t1", "test", nil)
+	assert.Equal(t, "urn:test:s:table:t1", entity.GetUrn())
+	assert.Equal(t, "table", entity.GetType())
+	assert.Nil(t, entity.GetProperties())
+}
+
+func TestNewEntityWithEmptyProps(t *testing.T) {
+	entity := models.NewEntity("urn:test:s:table:t1", "table", "t1", "test", map[string]any{})
+	assert.Equal(t, "urn:test:s:table:t1", entity.GetUrn())
+	assert.Nil(t, entity.GetProperties())
+}
+
+func TestNewEntityWithNestedProps(t *testing.T) {
+	entity := models.NewEntity("urn:test:s:table:t1", "table", "t1", "test", map[string]any{
+		"labels": map[string]string{"env": "production", "team": "data"},
+		"tags":   []string{"important", "verified"},
+	})
+	assert.Equal(t, "urn:test:s:table:t1", entity.GetUrn())
+	props := entity.GetProperties()
+	require.NotNil(t, props)
+	labelsVal := props.GetFields()["labels"].GetStructValue()
+	require.NotNil(t, labelsVal)
+	assert.Equal(t, "production", labelsVal.GetFields()["env"].GetStringValue())
+	assert.Equal(t, "data", labelsVal.GetFields()["team"].GetStringValue())
+	tagsVal := props.GetFields()["tags"].GetListValue()
+	require.NotNil(t, tagsVal)
+	assert.Len(t, tagsVal.GetValues(), 2)
+	assert.Equal(t, "important", tagsVal.GetValues()[0].GetStringValue())
+}
+
+func TestRecordToJSONWithoutEdges(t *testing.T) {
+	entity := &meteorv1beta1.Entity{
+		Urn:  "urn:test:s:table:t1",
+		Name: "t1",
+	}
+	record := models.NewRecord(entity)
+
+	b, err := models.RecordToJSON(record)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"entity"`)
+	assert.NotContains(t, string(b), `"edges"`)
+}
+
+func TestRecordToJSONWithMultipleEdges(t *testing.T) {
+	entity := &meteorv1beta1.Entity{
+		Urn:  "urn:test:s:table:t1",
+		Name: "t1",
+	}
+	lineage := models.LineageEdge("urn:a", "urn:b", "test")
+	owner := models.OwnerEdge("urn:test:s:table:t1", "urn:user:bob@co.com", "test")
+	record := models.NewRecord(entity, lineage, owner)
+
+	b, err := models.RecordToJSON(record)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"entity"`)
+	assert.Contains(t, s, `"edges"`)
+	assert.Contains(t, s, `"lineage"`)
+	assert.Contains(t, s, `"owned_by"`)
+	assert.Contains(t, s, `"urn:user:bob@co.com"`)
+}

--- a/plugins/processors/enrich/processor_test.go
+++ b/plugins/processors/enrich/processor_test.go
@@ -1,0 +1,135 @@
+//go:build plugins
+
+package enrich_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/raystack/meteor/models"
+	"github.com/raystack/meteor/plugins"
+	"github.com/raystack/meteor/plugins/processors/enrich"
+	testutils "github.com/raystack/meteor/test/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	t.Run("should return error for invalid config", func(t *testing.T) {
+		proc := enrich.New(testutils.Logger)
+		err := proc.Init(context.Background(), plugins.Config{
+			RawConfig: map[string]any{},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("should return no error for valid config", func(t *testing.T) {
+		proc := enrich.New(testutils.Logger)
+		err := proc.Init(context.Background(), plugins.Config{
+			RawConfig: map[string]any{
+				"attributes": map[string]any{
+					"team": "data-engineering",
+				},
+			},
+		})
+		assert.NoError(t, err)
+	})
+}
+
+func TestProcess(t *testing.T) {
+	t.Run("should enrich entity with nil properties", func(t *testing.T) {
+		proc := enrich.New(testutils.Logger)
+		err := proc.Init(context.Background(), plugins.Config{
+			RawConfig: map[string]any{
+				"attributes": map[string]any{
+					"team": "data-engineering",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		entity := models.NewEntity("urn:table:1", "table", "my-table", "bigquery", nil)
+		rec := models.NewRecord(entity)
+
+		result, err := proc.Process(context.Background(), rec)
+		require.NoError(t, err)
+
+		props := result.Entity().GetProperties().AsMap()
+		assert.Equal(t, "data-engineering", props["team"])
+	})
+
+	t.Run("should merge with existing properties", func(t *testing.T) {
+		proc := enrich.New(testutils.Logger)
+		err := proc.Init(context.Background(), plugins.Config{
+			RawConfig: map[string]any{
+				"attributes": map[string]any{
+					"team": "data-engineering",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		entity := models.NewEntity("urn:table:1", "table", "my-table", "bigquery", map[string]any{
+			"existing_key": "existing_value",
+		})
+		rec := models.NewRecord(entity)
+
+		result, err := proc.Process(context.Background(), rec)
+		require.NoError(t, err)
+
+		props := result.Entity().GetProperties().AsMap()
+		assert.Equal(t, "existing_value", props["existing_key"])
+		assert.Equal(t, "data-engineering", props["team"])
+	})
+
+	t.Run("should preserve edges through processing", func(t *testing.T) {
+		proc := enrich.New(testutils.Logger)
+		err := proc.Init(context.Background(), plugins.Config{
+			RawConfig: map[string]any{
+				"attributes": map[string]any{
+					"team": "data-engineering",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		entity := models.NewEntity("urn:table:1", "table", "my-table", "bigquery", nil)
+		lineage := models.LineageEdge("urn:table:1", "urn:table:2", "bigquery")
+		owner := models.OwnerEdge("urn:table:1", "urn:user:alice", "bigquery")
+		rec := models.NewRecord(entity, lineage, owner)
+
+		result, err := proc.Process(context.Background(), rec)
+		require.NoError(t, err)
+
+		assert.Len(t, result.Edges(), 2)
+		assert.Equal(t, lineage, result.Edges()[0])
+		assert.Equal(t, owner, result.Edges()[1])
+	})
+
+	t.Run("should only add string values and skip non-string values", func(t *testing.T) {
+		proc := enrich.New(testutils.Logger)
+		err := proc.Init(context.Background(), plugins.Config{
+			RawConfig: map[string]any{
+				"attributes": map[string]any{
+					"team":     "data-engineering",
+					"count":    42,
+					"enabled":  true,
+					"fraction": 3.14,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		entity := models.NewEntity("urn:table:1", "table", "my-table", "bigquery", nil)
+		rec := models.NewRecord(entity)
+
+		result, err := proc.Process(context.Background(), rec)
+		require.NoError(t, err)
+
+		props := result.Entity().GetProperties().AsMap()
+		assert.Equal(t, "data-engineering", props["team"])
+		assert.Nil(t, props["count"])
+		assert.Nil(t, props["enabled"])
+		assert.Nil(t, props["fraction"])
+	})
+}

--- a/plugins/processors/labels/labels_test.go
+++ b/plugins/processors/labels/labels_test.go
@@ -1,0 +1,147 @@
+//go:build plugins
+
+package labels_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/raystack/meteor/models"
+	meteorv1beta1 "github.com/raystack/meteor/models/raystack/meteor/v1beta1"
+	"github.com/raystack/meteor/plugins"
+	"github.com/raystack/meteor/plugins/processors/labels"
+	testutils "github.com/raystack/meteor/test/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	t.Run("should return error for invalid config", func(t *testing.T) {
+		p := labels.New(testutils.Logger)
+		err := p.Init(context.Background(), plugins.Config{
+			RawConfig: map[string]any{},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("should return no error for valid config", func(t *testing.T) {
+		p := labels.New(testutils.Logger)
+		err := p.Init(context.Background(), plugins.Config{
+			RawConfig: map[string]any{
+				"labels": map[string]any{
+					"team": "data-eng",
+				},
+			},
+		})
+		assert.NoError(t, err)
+	})
+}
+
+func TestProcess(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should add labels to entity with nil properties", func(t *testing.T) {
+		p := labels.New(testutils.Logger)
+		require.NoError(t, p.Init(ctx, plugins.Config{
+			RawConfig: map[string]any{
+				"labels": map[string]any{
+					"team": "data-eng",
+				},
+			},
+		}))
+
+		entity := models.NewEntity("urn:test:scope:table:t1", "table", "t1", "test", nil)
+		rec := models.NewRecord(entity)
+
+		result, err := p.Process(ctx, rec)
+		require.NoError(t, err)
+
+		props := result.Entity().GetProperties().AsMap()
+		lbls, ok := props["labels"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "data-eng", lbls["team"])
+	})
+
+	t.Run("should add labels to entity with existing properties but no labels", func(t *testing.T) {
+		p := labels.New(testutils.Logger)
+		require.NoError(t, p.Init(ctx, plugins.Config{
+			RawConfig: map[string]any{
+				"labels": map[string]any{
+					"env": "production",
+				},
+			},
+		}))
+
+		entity := models.NewEntity("urn:test:scope:table:t2", "table", "t2", "test", map[string]any{
+			"description": "some table",
+		})
+		rec := models.NewRecord(entity)
+
+		result, err := p.Process(ctx, rec)
+		require.NoError(t, err)
+
+		props := result.Entity().GetProperties().AsMap()
+		assert.Equal(t, "some table", props["description"])
+		lbls, ok := props["labels"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "production", lbls["env"])
+	})
+
+	t.Run("should merge labels with existing labels", func(t *testing.T) {
+		p := labels.New(testutils.Logger)
+		require.NoError(t, p.Init(ctx, plugins.Config{
+			RawConfig: map[string]any{
+				"labels": map[string]any{
+					"env":  "production",
+					"team": "data-eng",
+				},
+			},
+		}))
+
+		entity := models.NewEntity("urn:test:scope:table:t3", "table", "t3", "test", map[string]any{
+			"labels": map[string]any{
+				"existing": "value",
+				"team":     "old-team",
+			},
+		})
+		rec := models.NewRecord(entity)
+
+		result, err := p.Process(ctx, rec)
+		require.NoError(t, err)
+
+		props := result.Entity().GetProperties().AsMap()
+		lbls, ok := props["labels"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "value", lbls["existing"])
+		assert.Equal(t, "data-eng", lbls["team"])
+		assert.Equal(t, "production", lbls["env"])
+	})
+
+	t.Run("should preserve edges through processing", func(t *testing.T) {
+		p := labels.New(testutils.Logger)
+		require.NoError(t, p.Init(ctx, plugins.Config{
+			RawConfig: map[string]any{
+				"labels": map[string]any{
+					"team": "data-eng",
+				},
+			},
+		}))
+
+		entity := models.NewEntity("urn:test:scope:table:t4", "table", "t4", "test", nil)
+		edges := []*meteorv1beta1.Edge{
+			models.OwnerEdge("urn:test:scope:table:t4", "urn:test:scope:user:alice", "test"),
+			models.LineageEdge("urn:test:scope:table:t4", "urn:test:scope:table:t5", "test"),
+		}
+		rec := models.NewRecord(entity, edges...)
+
+		result, err := p.Process(ctx, rec)
+		require.NoError(t, err)
+
+		resultEdges := result.Edges()
+		require.Len(t, resultEdges, 2)
+		assert.Equal(t, "owned_by", resultEdges[0].Type)
+		assert.Equal(t, "urn:test:scope:user:alice", resultEdges[0].TargetUrn)
+		assert.Equal(t, "lineage", resultEdges[1].Type)
+		assert.Equal(t, "urn:test:scope:table:t5", resultEdges[1].TargetUrn)
+	})
+}

--- a/plugins/processors/script/tengo_script_test.go
+++ b/plugins/processors/script/tengo_script_test.go
@@ -126,6 +126,46 @@ func TestProcess(t *testing.T) {
 			errStr:   "invalid keys: does_not_exist",
 		},
 		{
+			name:   "ModifyEntityName",
+			script: `asset.name = "new-name"`,
+			input: &meteorv1beta1.Entity{
+				Urn:    "urn:test:test:table:test",
+				Name:   "old-name",
+				Source: "test",
+				Type:   "table",
+			},
+			expected: &meteorv1beta1.Entity{
+				Urn:    "urn:test:test:table:test",
+				Name:   "new-name",
+				Source: "test",
+				Type:   "table",
+			},
+		},
+		{
+			name: "EntityWithNilProperties",
+			script: heredoc.Doc(`
+				asset.properties = {new_key: "new_value"}
+			`),
+			input: &meteorv1beta1.Entity{
+				Urn:    "urn:test:test:table:test",
+				Name:   "test",
+				Source: "test",
+				Type:   "table",
+			},
+			expected: &meteorv1beta1.Entity{
+				Urn:    "urn:test:test:table:test",
+				Name:   "test",
+				Source: "test",
+				Type:   "table",
+				Properties: func() *structpb.Struct {
+					s, _ := structpb.NewStruct(map[string]any{
+						"new_key": "new_value",
+					})
+					return s
+				}(),
+			},
+		},
+		{
 			name:   "ErrRunContext",
 			script: heredoc.Doc(`a := 5 / 0`),
 			input: &meteorv1beta1.Entity{
@@ -166,4 +206,58 @@ func TestProcess(t *testing.T) {
 			testutils.AssertEqualProto(t, tc.expected, res.Entity())
 		})
 	}
+
+	t.Run("PreservesEdges", func(t *testing.T) {
+		p := New(testutils.Logger)
+		err := p.Init(ctx, plugins.Config{
+			RawConfig: map[string]any{
+				"script": `asset.name = "modified"`,
+				"engine": "tengo",
+			},
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		edges := []*meteorv1beta1.Edge{
+			{
+				SourceUrn: "urn:test:test:table:src",
+				TargetUrn: "urn:test:test:user:owner1",
+				Type:      "owned_by",
+				Source:     "test",
+			},
+			{
+				SourceUrn: "urn:test:test:table:src",
+				TargetUrn: "urn:test:test:table:upstream",
+				Type:      "lineage",
+				Source:     "test",
+			},
+		}
+
+		input := models.NewRecord(
+			&meteorv1beta1.Entity{
+				Urn:    "urn:test:test:table:src",
+				Name:   "original",
+				Source: "test",
+				Type:   "table",
+			},
+			edges...,
+		)
+
+		res, err := p.Process(ctx, input)
+		assert.NoError(t, err)
+
+		testutils.AssertEqualProto(t, &meteorv1beta1.Entity{
+			Urn:    "urn:test:test:table:src",
+			Name:   "modified",
+			Source: "test",
+			Type:   "table",
+		}, res.Entity())
+
+		gotEdges := res.Edges()
+		assert.Len(t, gotEdges, 2)
+		for i, e := range edges {
+			testutils.AssertEqualProto(t, e, gotEdges[i])
+		}
+	})
 }

--- a/plugins/sinks/compass/sink_test.go
+++ b/plugins/sinks/compass/sink_test.go
@@ -47,6 +47,21 @@ func TestSink(t *testing.T) {
 	upsertEntityURL := fmt.Sprintf("%s/raystack.compass.v1beta1.CompassService/UpsertEntity", host)
 	upsertEdgeURL := fmt.Sprintf("%s/raystack.compass.v1beta1.CompassService/UpsertEdge", host)
 
+	t.Run("should handle empty batch without error", func(t *testing.T) {
+		client := &mockHTTPClient{}
+		ctx := context.TODO()
+
+		compassSink := compass.New(client, testutils.Logger)
+		err := compassSink.Init(ctx, plugins.Config{RawConfig: map[string]any{
+			"host": host,
+		}})
+		require.NoError(t, err)
+
+		err = compassSink.Sink(ctx, []models.Record{})
+		assert.NoError(t, err)
+		assert.Empty(t, client.requests)
+	})
+
 	t.Run("should return error if compass host returns error", func(t *testing.T) {
 		client := &mockHTTPClient{}
 		client.SetupResponse(404, `{"reason":"not found"}`)

--- a/plugins/sinks/console/sink_test.go
+++ b/plugins/sinks/console/sink_test.go
@@ -1,0 +1,87 @@
+//go:build plugins
+
+package console_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/raystack/meteor/models"
+	meteorv1beta1 "github.com/raystack/meteor/models/raystack/meteor/v1beta1"
+	"github.com/raystack/meteor/plugins"
+	"github.com/raystack/meteor/plugins/sinks/console"
+	testutils "github.com/raystack/meteor/test/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	t.Run("should return no error for valid config", func(t *testing.T) {
+		sink := console.New(testutils.Logger)
+		err := sink.Init(context.Background(), plugins.Config{RawConfig: map[string]interface{}{}})
+		assert.NoError(t, err)
+	})
+}
+
+func TestSink(t *testing.T) {
+	t.Run("should sink single record without error", func(t *testing.T) {
+		sink := console.New(testutils.Logger)
+		require.NoError(t, sink.Init(context.Background(), plugins.Config{RawConfig: map[string]interface{}{}}))
+
+		entity := models.NewEntity("urn:test:scope:table:myid", "table", "my-table", "test", nil)
+		record := models.NewRecord(entity)
+
+		err := sink.Sink(context.Background(), []models.Record{record})
+		assert.NoError(t, err)
+	})
+
+	t.Run("should sink multiple records without error", func(t *testing.T) {
+		sink := console.New(testutils.Logger)
+		require.NoError(t, sink.Init(context.Background(), plugins.Config{RawConfig: map[string]interface{}{}}))
+
+		records := []models.Record{
+			models.NewRecord(models.NewEntity("urn:test:scope:table:t1", "table", "table-1", "test", nil)),
+			models.NewRecord(models.NewEntity("urn:test:scope:topic:t2", "topic", "topic-1", "kafka", map[string]any{
+				"partitions": 3,
+			})),
+		}
+
+		err := sink.Sink(context.Background(), records)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should handle empty batch", func(t *testing.T) {
+		sink := console.New(testutils.Logger)
+		require.NoError(t, sink.Init(context.Background(), plugins.Config{RawConfig: map[string]interface{}{}}))
+
+		err := sink.Sink(context.Background(), []models.Record{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("should sink record with edges", func(t *testing.T) {
+		sink := console.New(testutils.Logger)
+		require.NoError(t, sink.Init(context.Background(), plugins.Config{RawConfig: map[string]interface{}{}}))
+
+		entity := models.NewEntity("urn:test:scope:table:t1", "table", "my-table", "test", map[string]any{
+			"database": "testdb",
+		})
+		edges := []*meteorv1beta1.Edge{
+			models.OwnerEdge("urn:test:scope:table:t1", "urn:test:scope:user:alice", "test"),
+			models.LineageEdge("urn:test:scope:table:upstream", "urn:test:scope:table:t1", "test"),
+		}
+		record := models.NewRecord(entity, edges...)
+
+		err := sink.Sink(context.Background(), []models.Record{record})
+		assert.NoError(t, err)
+	})
+}
+
+func TestClose(t *testing.T) {
+	t.Run("should return nil on close", func(t *testing.T) {
+		sink := console.New(testutils.Logger)
+		require.NoError(t, sink.Init(context.Background(), plugins.Config{RawConfig: map[string]interface{}{}}))
+
+		err := sink.Close()
+		assert.NoError(t, err)
+	})
+}

--- a/plugins/sinks/file/file_test.go
+++ b/plugins/sinks/file/file_test.go
@@ -80,6 +80,64 @@ func TestSink(t *testing.T) {
 		}
 		assert.Error(t, sinkInvalidPath(t, config))
 	})
+
+	t.Run("should sink empty batch without error", func(t *testing.T) {
+		fileSink := f.New(testUtils.Logger)
+		err := fileSink.Init(context.TODO(), plugins.Config{RawConfig: validConfig})
+		assert.NoError(t, err)
+		err = fileSink.Sink(context.TODO(), []models.Record{})
+		assert.NoError(t, err)
+		assert.NoError(t, fileSink.Close())
+	})
+
+	t.Run("should sink records with edges in ndjson format", func(t *testing.T) {
+		config := map[string]any{
+			"path":   "./test-dir/edges.ndjson",
+			"format": "ndjson",
+		}
+		fileSink := f.New(testUtils.Logger)
+		err := fileSink.Init(context.TODO(), plugins.Config{RawConfig: config})
+		assert.NoError(t, err)
+
+		entity := &meteorv1beta1.Entity{
+			Urn:    "urn:bigquery:p:table:d.t1",
+			Name:   "t1",
+			Source: "bigquery",
+			Type:   "table",
+		}
+		edges := []*meteorv1beta1.Edge{
+			{SourceUrn: "urn:upstream", TargetUrn: "urn:bigquery:p:table:d.t1", Type: "lineage", Source: "bigquery"},
+			{SourceUrn: "urn:bigquery:p:table:d.t1", TargetUrn: "urn:user:alice@co.com", Type: "owned_by", Source: "bigquery"},
+		}
+		record := models.NewRecord(entity, edges...)
+		err = fileSink.Sink(context.TODO(), []models.Record{record})
+		assert.NoError(t, err)
+		assert.NoError(t, fileSink.Close())
+	})
+
+	t.Run("should sink records with edges in yaml format", func(t *testing.T) {
+		config := map[string]any{
+			"path":   "./test-dir/edges.yaml",
+			"format": "yaml",
+		}
+		fileSink := f.New(testUtils.Logger)
+		err := fileSink.Init(context.TODO(), plugins.Config{RawConfig: config})
+		assert.NoError(t, err)
+
+		entity := &meteorv1beta1.Entity{
+			Urn:    "urn:bigquery:p:table:d.t1",
+			Name:   "t1",
+			Source: "bigquery",
+			Type:   "table",
+		}
+		edges := []*meteorv1beta1.Edge{
+			{SourceUrn: "urn:upstream", TargetUrn: "urn:bigquery:p:table:d.t1", Type: "lineage", Source: "bigquery"},
+		}
+		record := models.NewRecord(entity, edges...)
+		err = fileSink.Sink(context.TODO(), []models.Record{record})
+		assert.NoError(t, err)
+		assert.NoError(t, fileSink.Close())
+	})
 }
 
 func sinkInvalidPath(t *testing.T, config map[string]any) error {

--- a/plugins/sinks/file/test-dir/edges.ndjson
+++ b/plugins/sinks/file/test-dir/edges.ndjson
@@ -1,0 +1,1 @@
+{"edges":[{"source_urn":"urn:upstream","target_urn":"urn:bigquery:p:table:d.t1","type":"lineage","source":"bigquery"},{"source_urn":"urn:bigquery:p:table:d.t1","target_urn":"urn:user:alice@co.com","type":"owned_by","source":"bigquery"}],"entity":{"urn":"urn:bigquery:p:table:d.t1","type":"table","name":"t1","source":"bigquery"}}

--- a/plugins/sinks/file/test-dir/edges.yaml
+++ b/plugins/sinks/file/test-dir/edges.yaml
@@ -1,0 +1,10 @@
+- edges:
+    - source: bigquery
+      source_urn: urn:upstream
+      target_urn: urn:bigquery:p:table:d.t1
+      type: lineage
+  entity:
+    name: t1
+    source: bigquery
+    type: table
+    urn: urn:bigquery:p:table:d.t1

--- a/plugins/sinks/kafka/sink_test.go
+++ b/plugins/sinks/kafka/sink_test.go
@@ -1,0 +1,63 @@
+//go:build plugins
+// +build plugins
+
+package kafka_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/raystack/meteor/plugins"
+	"github.com/raystack/meteor/plugins/sinks/kafka"
+	testutils "github.com/raystack/meteor/test/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	t.Run("should return InvalidConfigError on invalid config", func(t *testing.T) {
+		invalidConfigs := []map[string]any{
+			{},
+			{"brokers": "localhost:9092"},
+			{"topic": "test-topic"},
+			{"brokers": "", "topic": ""},
+		}
+		for i, config := range invalidConfigs {
+			t.Run(fmt.Sprintf("test invalid config #%d", i+1), func(t *testing.T) {
+				sink := kafka.New(testutils.Logger)
+				err := sink.Init(context.TODO(), plugins.Config{RawConfig: config})
+
+				assert.ErrorAs(t, err, &plugins.InvalidConfigError{})
+			})
+		}
+	})
+
+	t.Run("should not return error on valid config", func(t *testing.T) {
+		sink := kafka.New(testutils.Logger)
+		err := sink.Init(context.TODO(), plugins.Config{RawConfig: map[string]any{
+			"brokers": "localhost:9092",
+			"topic":   "test-topic",
+		}})
+
+		require.NoError(t, err)
+
+		// Clean up the writer created during Init.
+		err = sink.Close()
+		assert.NoError(t, err)
+	})
+
+	t.Run("should not return error on valid config with key_path", func(t *testing.T) {
+		sink := kafka.New(testutils.Logger)
+		err := sink.Init(context.TODO(), plugins.Config{RawConfig: map[string]any{
+			"brokers":  "localhost:9092",
+			"topic":    "test-topic",
+			"key_path": ".Urn",
+		}})
+
+		require.NoError(t, err)
+
+		err = sink.Close()
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
- Restores test coverage lost during the Asset → Entity+Edge migration (706 lines added across 11 files)
- Adds **4 new test files** for previously untested components: enrich processor, labels processor, console sink, kafka sink
- Strengthens **5 existing test files** with edge-case coverage: models (record, util), script processor, compass sink, file sink

## New test files
| Component | Coverage |
|-----------|----------|
| `processors/enrich` | Init validation, Process with nil/existing properties, edge passthrough, non-string value skip |
| `processors/labels` | Init validation, Process with nil/existing labels, label merging, edge passthrough |
| `sinks/console` | Init, Sink with single/multiple/empty batches, records with edges, Close |
| `sinks/kafka` | Init config validation (missing brokers, missing topic, empty strings) |

## Strengthened tests
| Component | Added |
|-----------|-------|
| `models/record` | Multiple edges, nil entity handling |
| `models/util` | Nil/empty props, nested props sanitization, JSON serialization with/without edges |
| `processors/script` | Modify entity name, nil properties, edge preservation through processing |
| `sinks/compass` | Empty batch handling |
| `sinks/file` | Empty batch, records with edges in ndjson and yaml formats |

## Test plan
- [x] All new tests pass with `go test -tags=plugins ./...`
- [x] Full test suite passes (only pre-existing BigQuery ARM64 Docker image issue)
- [x] No regressions in existing tests